### PR TITLE
Remove closing on bytes

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -543,7 +543,6 @@ def callServer(verb, serverEndpoint, service, data, headers, verbose=Verbose, ti
     effectiveRequestOptions.update(requestOptions)
 
     resp = verbFn(serviceUrl, encodedData, **effectiveRequestOptions)
-    encodedData.close() # closes the file reading data
 
     if verbose:
         print(sys.stderr, "Request headers: ", headers)


### PR DESCRIPTION
Actually as the callServer get's the reader from the parent, the parent should be responsible for closing it. 

If the caller needs to have the file opened less time it should manage the read itself and after that call callServer with bytes directly in my opinion.